### PR TITLE
Corrected output when passing incorrect arguments

### DIFF
--- a/doorman/main/doorman.cpp
+++ b/doorman/main/doorman.cpp
@@ -131,8 +131,8 @@ return 0;
 }
 
 int main(int argc, char ** argv) {
-  if (argc < 3) {
-    fprintf(stderr, "Invalid number of arguments: %d, required at least 2 \nUsage: %s <pin> <mode>\n", argc - 1, argv[0]);
+  if (argc < 4) {
+    fprintf(stderr, "Invalid number of arguments: %d, required at least 3 \nUsage: %s <pin> <mode>\n", argc - 1, argv[0]);
     return 1;
   }
 
@@ -149,7 +149,7 @@ int main(int argc, char ** argv) {
     }
     return do_write(pin, argv[3], argv[4]);
   } else {
-    fprintf(stderr, "Invalid mode \"%s\", valid modes are \"read\", \"read-human\" and \"write <channel> <sound>\"\n", argv[1]);
+    fprintf(stderr, "Invalid mode \"%s\", valid modes are \"read\", \"read-human\" and \"write <channel> <sound>\"\n", argv[2]);
     return 1;
   }
 }

--- a/doorman/main/doorman.cpp
+++ b/doorman/main/doorman.cpp
@@ -105,7 +105,7 @@ int do_write(int pin, char *channel_str, char *sound_str) {
 
   int sound_bit = sound_map[sound - 1];
 
-  for(int i = 0; i < 10; i++){
+  for(int i = 0; i < 100; i++){
     for(int j = 3; j >= 0; j--){
        doorman::write(1);
        delayMicroseconds(delay);


### PR DESCRIPTION
The first argument passed is the pin number not the mode any more and because the pin was added 3 arguments is now the minimum.

Sending the signal only 10 times to the receiver is apparently not enough the be sure that is is correctly received. Increased it to 100 to be more robust.
